### PR TITLE
Update php version for D8

### DIFF
--- a/islandora_videojs.info.yml
+++ b/islandora_videojs.info.yml
@@ -6,4 +6,4 @@ package: 'Islandora Viewers'
 configure: islandora_video_js.admin
 core: 8.x
 type: module
-php: '5.5.9'
+php: '7.2'


### PR DESCRIPTION
php 5 support is being dropped:
[Drupal docs](https://www.drupal.org/docs/8/system-requirements/php-requirements)